### PR TITLE
Use LocalDate for session start time calculation

### DIFF
--- a/Reef/src/main/java/dev/pranav/reef/routine/Routines.kt
+++ b/Reef/src/main/java/dev/pranav/reef/routine/Routines.kt
@@ -157,7 +157,7 @@ object Routines {
 
         val newSession = ActiveSession(
             routineId = routine.id,
-            startTime = LocalDate.now().atTime(routine.schedule.time).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),,
+            startTime = LocalDate.now().atTime(routine.schedule.time).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
             limits = routine.limits.associate { it.packageName to it.limitMinutes * 60_000L }
         )
         sessions.add(newSession)


### PR DESCRIPTION
Replaced System.currentTimeMillis() with LocalDate.now().atTime(...).atZone(...).toInstant().toEpochMilli() for more accurate session start time based on the routine's scheduled time and system time zone.