### PR TITLE
fix: restore dnd on focus pause

### DIFF
--- a/Reef/src/main/java/dev/pranav/reef/accessibility/FocusModeService.kt
+++ b/Reef/src/main/java/dev/pranav/reef/accessibility/FocusModeService.kt
@@ -270,10 +270,11 @@ class FocusModeService: Service() {
 
         if (!state.isPomodoroMode) {
             endSession()
-            return
+        } else {
+            transitionPomodoroPhase()
         }
 
-        transitionPomodoroPhase()
+
     }
 
     private fun endSession() {
@@ -341,16 +342,15 @@ class FocusModeService: Service() {
                 showBreakEndedNotification()
             }
         } else {
-            if (!shouldAutoStart) {
-                restoreDND()
-            }
+            restoreDND()
         }
 
         if (prefs.getBoolean("pomodoro_sound_enabled", true)) {
-            if (prefs.getBoolean("pomodoro_vibration_enabled", true)) {
-                AndroidUtilities.vibrate(this, 1000)
-            }
             playTransitionSound()
+        }
+
+        if (prefs.getBoolean("pomodoro_vibration_enabled", true)) {
+            AndroidUtilities.vibrate(this, 1000)
         }
 
         val notificationText = if (shouldAutoStart) {


### PR DESCRIPTION
This pull request primarily focuses on correctly restoring Do Not Disturb (DND) mode and refining the Pomodoro phase transition logic. The changes ensure DND is restored at appropriate times and that Pomodoro transitions are handled more clearly and efficiently.

**Focus mode and Pomodoro logic improvements:**

* Restores DND mode immediately when focus mode ends by calling `restoreDND()` at the end of a session.
* Refactors Pomodoro phase transition logic to only call `transitionPomodoroPhase()` if the session is in Pomodoro mode, improving clarity and correctness.

**Notification and feedback handling:**

* Ensures DND is restored at the start of a Pomodoro break phase regardless of auto-start settings, and refactors the order and conditions for playing transition sounds and vibrations for better reliability.