### PR TITLE
Refine usage fallback logic with 1-day threshold

### DIFF
--- a/Reef/src/main/java/dev/pranav/reef/util/ScreenUsageHelper.kt
+++ b/Reef/src/main/java/dev/pranav/reef/util/ScreenUsageHelper.kt
@@ -29,19 +29,27 @@ object ScreenUsageHelper {
         end: Long,
         targetPackage: String? = null
     ): Map<String, Long> {
+        fun Map<*, Long>.totalTime(): Long = values.sum()
+        val ONE_DAY_MS: Long = 24 * 60 * 60 * 1000L
+
         try {
-            val eventBasedUsage =
+            var usage =
                 calculateUsageFromEvents(usageStatsManager, start, end, targetPackage)
 
-            if (eventBasedUsage.isEmpty()) {
-                Log.w(TAG, "Event-based tracking returned no data, using UsageStats fallback")
-                return calculateUsageFromStats(usageStatsManager, start, end, targetPackage)
+            if (!usage.isEmpty() && usage.totalTime() <= ONE_DAY_MS) {
+                return usage
             }
 
-            return eventBasedUsage
+            usage = calculateUsageFromStats(usageStatsManager, start, end, targetPackage)
+
+            if (usage.totalTime() <= ONE_DAY_MS) {
+                return usage
+            }
+
+            return emptyMap()
         } catch (e: Exception) {
             Log.e(TAG, "Error fetching usage", e)
-            return calculateUsageFromStats(usageStatsManager, start, end, targetPackage)
+            return emptyMap()
         }
     }
 


### PR DESCRIPTION
Days from past weeks show sometimes a usage higher than 24 hours, what is physically impossible. This PR aims to hide usage for those days where stats are not precise.