### PR TITLE
Fix/transition sound not playing

### DIFF
--- a/Reef/src/main/java/dev/pranav/reef/accessibility/FocusModeService.kt
+++ b/Reef/src/main/java/dev/pranav/reef/accessibility/FocusModeService.kt
@@ -8,6 +8,7 @@ import android.app.Service
 import android.content.Intent
 import android.content.Intent.FLAG_RECEIVER_FOREGROUND
 import android.content.pm.ServiceInfo
+import android.media.AudioAttributes
 import android.os.Build
 import android.os.CountDownTimer
 import android.os.IBinder

--- a/Reef/src/main/java/dev/pranav/reef/accessibility/FocusModeService.kt
+++ b/Reef/src/main/java/dev/pranav/reef/accessibility/FocusModeService.kt
@@ -620,6 +620,12 @@ class FocusModeService: Service() {
             }
 
             val ringtone = android.media.RingtoneManager.getRingtone(applicationContext, soundUri)
+
+            ringtone?.audioAttributes = AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_ALARM)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .build()
+
             ringtone?.play()
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
Given that the option 'Play sound on phase transitions' is enabled, the sound is not playing when transitioning from a break to focus. This PR aims to fix this behaviour.