### PR TITLE
feat: Switch to 12-hour time format in routines

### DIFF
--- a/Reef/src/main/java/dev/pranav/reef/screens/CreateRoutineScreen.kt
+++ b/Reef/src/main/java/dev/pranav/reef/screens/CreateRoutineScreen.kt
@@ -1169,7 +1169,7 @@ private fun TimePickerDialog(
     val timePickerState = rememberTimePickerState(
         initialHour = initialTime.hour,
         initialMinute = initialTime.minute,
-        is24Hour = true
+        is24Hour = false
     )
 
     AlertDialog(
@@ -1445,7 +1445,7 @@ private fun loadAccessibleApps(context: android.content.Context): List<Pair<Stri
 }
 
 private fun formatTime(time: LocalTime): String {
-    val formatter = DateTimeFormatter.ofPattern("HH:mm")
+    val formatter = DateTimeFormatter.ofPattern("hh:mm a")
     return time.format(formatter)
 }
 

--- a/Reef/src/main/java/dev/pranav/reef/screens/RoutinesScreen.kt
+++ b/Reef/src/main/java/dev/pranav/reef/screens/RoutinesScreen.kt
@@ -316,6 +316,6 @@ private fun formatSchedule(schedule: RoutineSchedule?, context: android.content.
 }
 
 private fun formatTime(time: LocalTime): String {
-    val formatter = DateTimeFormatter.ofPattern("HH:mm")
+    val formatter = DateTimeFormatter.ofPattern("hh:mm a")
     return time.format(formatter)
 }


### PR DESCRIPTION
Updated the routine creation and display logic to use a **12-hour time format (AM/PM)** instead of the 24-hour format. This improves readability and provides a more familiar user experience when setting up daily schedules.